### PR TITLE
Add documentation for fetchAssoc `=` operator

### DIFF
--- a/www/cs/documentation.texy
+++ b/www/cs/documentation.texy
@@ -509,6 +509,12 @@ $all = $result->fetchAssoc('name|order_id');
 $order = $all['Arnold Rimmer'][$orderId];
 ```
 
+A když bychom chtěli data vypsat třeba rovnou do html selectboxu a potřebovali bychom vrátit jen sloupec a ne celý řádek, stačí použít znak rovná se:
+
+```php
+$all = $result->fetchAssoc('name|order_id=number');
+```
+
 Co když ale existuje více zákazníků se stejným jménem? Tabulka by měla mít spíš tvar:
 
 ```php
@@ -566,7 +572,6 @@ foreach ($all as $customerId => $row) {
    }
 }
 ```
-
 
 Prefixy & substituce
 ====================

--- a/www/en/documentation.texy
+++ b/www/en/documentation.texy
@@ -510,6 +510,12 @@ $all = $result->fetchAssoc('name|order_id');
 $order = $all['Arnold Rimmer'][$orderId];
 ```
 
+And if we would like to dump the data directly into the html selectbox and we need to return only a column and not the whole row, we can just use the equals sign:
+
+```php
+$all = $result->fetchAssoc('name|order_id=number');
+```
+
 But what if there are more customers with the same name? The table should be in the form of:
 
 ```php


### PR DESCRIPTION
The source code contains documentation for the `fetchAssoc` method that mentions the possibility of using the `=` operator, which is not mentioned in the web documentation. I am sending a pull-request as agreed.